### PR TITLE
Modify SQL query to find longest book title

### DIFF
--- a/sql-part-2/studio/SQL-Part-2-Studio.ipynb
+++ b/sql-part-2/studio/SQL-Part-2-Studio.ipynb
@@ -63,7 +63,11 @@
         {
             "cell_type": "code",
             "source": [
-                "-- Code here:"
+                select top 1 len(title) as title_length, title
+from BooksDB.dbo.books
+ORDER BY title_length desc
+--186 characters: Soccernomics: Why England Loses, Why Germany and Brazil Win, and Why the U.S., Japan, Australia, Turkey--and Even Iraq--Are Destined to Become the Kings of the World's Most Popular Sport
+--THE LONGEST TITLE
             ],
             "metadata": {
                 "azdata_cell_guid": "fc1a211d-ea4e-446a-bbf8-e31499c50aba"


### PR DESCRIPTION
Updated SQL query to select the longest book title from BooksDB.